### PR TITLE
check blog post locale on page mount

### DIFF
--- a/src/views/PostView.vue
+++ b/src/views/PostView.vue
@@ -326,7 +326,17 @@ export default {
 		},
 	},
 	mounted() {
-		const locale = this.$i18n.locale;
+		let locale = "en";
+
+		// check locale for old posts.
+		if (this.$route.path.endsWith("-en")) {
+			locale = "en";
+		} else if (this.$route.path.endsWith("-cn")) {
+			locale = "cn";
+		} else {
+			locale = this.$i18n.locale;
+		}
+
 		this.getContent(locale);
 		this.getMayAlsoLikeArticles(locale);
 	},


### PR DESCRIPTION
Blog post md files fetched depend on locale. If your locale is `en` but you are directly visited website to see `cn` article by link, article cannot be displayed . To fix it: check path to set locale. 