### PR TITLE
filling page issue fix

### DIFF
--- a/src/assets/css/styles.css
+++ b/src/assets/css/styles.css
@@ -1095,6 +1095,10 @@
 	color: #515651;
 }
 
+.documentCardContent a {
+	flex: 1;
+}
+
 /* donations to etc section starts here */
 .donationsToEtcSection {
 	padding: 0px 32px;


### PR DESCRIPTION
Style fix for `filling` page

**OLD ONE**

![image (2)](https://github.com/ETCCooperative/etc-coop-website/assets/102132498/7163d787-3105-4c1a-9bd0-86f829f32949)

**NEW ONE** 

<img width="746" alt="Screenshot 2023-08-14 at 14 26 51" src="https://github.com/ETCCooperative/etc-coop-website/assets/102132498/30c1cc71-d146-4269-b555-e0dfd2b337c0">
