### PR TITLE
fix: correct broken GitHub repo links on Development page

### DIFF
--- a/src/config/cn/development.projects.json
+++ b/src/config/cn/development.projects.json
@@ -18,7 +18,7 @@
 			"status": "in-development",
 			"statusLabel": "开发中",
 			"description": "扩展 Hyperledger Besu 的插件 API 以支持外部共识层。同时正在修复影响以太坊和以太坊经典网络的同步问题。插件扩展点正在贡献给上游，以实现 ETC 支持作为独立插件而无需修改 Besu 核心。",
-			"repo": "https://github.com/ETCCooperative/besu-etc-plugin",
+			"repo": "https://github.com/diega/besu-etc-plugin",
 			"links": [
 				{
 					"label": "同步修复 (ETH & ETC)",
@@ -36,7 +36,7 @@
 			"status": "experimental",
 			"statusLabel": "实验性",
 			"description": "一个易于变基的 ETC 客户端，仅在未修改的上游 go-ethereum 之上构建了 9 个提交。设计使得上游改进可以通过简单的变基操作吸收。目前正在持续测试中，调查 PoW 网络特有的坏块传播问题。",
-			"repo": "https://github.com/etccooperative/go-ethereum-classic",
+			"repo": "https://github.com/diega/go-ethereum-classic",
 			"links": [
 				{
 					"label": "坏块问题（开放，上游）",
@@ -67,14 +67,14 @@
 			"status": "experimental",
 			"statusLabel": "实验性",
 			"description": "探索以太坊共识层/执行层架构的相似性，以及如何将其应用于以太坊经典。一个用 Rust 编写的工作量证明共识层，通过标准 Engine API 与执行客户端通信。",
-			"repo": "https://github.com/etccooperative/etc-cl"
+			"repo": "https://github.com/diega/etc-cl"
 		},
 		{
 			"name": "PeerShark",
 			"status": "experimental",
 			"statusLabel": "实验性",
 			"description": "以太坊 P2P 协议的网络层调试工具。一个透明的流量分析器，用于诊断 devp2p 网络中的节点连接、消息传播和协议级别问题。",
-			"repo": "https://github.com/etccooperative/peershark"
+			"repo": "https://github.com/diega/peershark"
 		}
 	],
 	"infrastructure": [

--- a/src/config/en/development.projects.json
+++ b/src/config/en/development.projects.json
@@ -18,7 +18,7 @@
 			"status": "in-development",
 			"statusLabel": "In Development",
 			"description": "Extending Hyperledger Besu's plugin API to support external consensus layers. Parallel work is underway fixing synchronization issues that affect both Ethereum and Ethereum Classic networks. Plugin extension points are being contributed upstream to enable ETC support as a standalone plugin without modifying Besu core.",
-			"repo": "https://github.com/ETCCooperative/besu-etc-plugin",
+			"repo": "https://github.com/diega/besu-etc-plugin",
 			"links": [
 				{
 					"label": "Sync fix (ETH & ETC)",
@@ -36,7 +36,7 @@
 			"status": "experimental",
 			"statusLabel": "Experimental",
 			"description": "A rebase-friendly ETC client built as just 9 commits on top of unmodified upstream go-ethereum. Designed so that upstream improvements can be absorbed with a straightforward rebase. Currently in continuous testing, investigating bad block propagation issues specific to PoW networks.",
-			"repo": "https://github.com/etccooperative/go-ethereum-classic",
+			"repo": "https://github.com/diega/go-ethereum-classic",
 			"links": [
 				{
 					"label": "BAD BLOCK (open, upstream)",
@@ -67,14 +67,14 @@
 			"status": "experimental",
 			"statusLabel": "Experimental",
 			"description": "Exploring the proximity between Ethereum's consensus layer / execution layer architecture and how it could be leveraged for Ethereum Classic. A Proof-of-Work consensus layer written in Rust, communicating with a standard execution client via the Engine API.",
-			"repo": "https://github.com/etccooperative/etc-cl"
+			"repo": "https://github.com/diega/etc-cl"
 		},
 		{
 			"name": "PeerShark",
 			"status": "experimental",
 			"statusLabel": "Experimental",
 			"description": "Network layer debugging tool for Ethereum P2P protocols. A transparent traffic analyzer for diagnosing peer connectivity, message propagation, and protocol-level issues across devp2p networks.",
-			"repo": "https://github.com/etccooperative/peershark"
+			"repo": "https://github.com/diega/peershark"
 		}
 	],
 	"infrastructure": [


### PR DESCRIPTION
## Summary
- Four repo links on the Development page pointed to `etccooperative/` but the repos actually live under `diega/`: besu-etc-plugin, go-ethereum-classic, etc-cl, and peershark
- Fixed in both EN and CN config files

## Test plan
- [ ] Verify each repo link on the Development page resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)