### PR TITLE
fix: update Go-Ethereum-Classic with bad block root cause

### DIFF
--- a/src/config/cn/development.projects.json
+++ b/src/config/cn/development.projects.json
@@ -35,7 +35,7 @@
 			"nameNote": "暂定名称",
 			"status": "experimental",
 			"statusLabel": "实验性",
-			"description": "一个易于变基的 ETC 客户端，仅在未修改的上游 go-ethereum 之上构建了 9 个提交。设计使得上游改进可以通过简单的变基操作吸收。目前正在持续测试中，调查 PoW 网络特有的坏块传播问题。",
+			"description": "一个易于变基的 ETC 客户端，仅在未修改的上游 go-ethereum 之上构建了 9 个提交。设计使得上游改进可以通过简单的变基操作吸收。对 PoW 网络坏块传播的调查将根本原因追溯到 PathDB 中的一个 bug：具有重复状态根的侧链区块会静默地破坏规范状态读取。修复已提交到上游。",
 			"repo": "https://github.com/diega/go-ethereum-classic",
 			"links": [
 				{
@@ -43,12 +43,8 @@
 					"url": "https://github.com/ethereum/go-ethereum/issues/32386"
 				},
 				{
-					"label": "状态损坏修复",
-					"url": "https://github.com/ethereum/go-ethereum/pull/33931"
-				},
-				{
-					"label": "PathDB 锁修复",
-					"url": "https://github.com/ethereum/go-ethereum/pull/33622"
+					"label": "根本原因修复（开放，上游）",
+					"url": "https://github.com/ethereum/go-ethereum/pull/34642"
 				}
 			]
 		},

--- a/src/config/en/development.projects.json
+++ b/src/config/en/development.projects.json
@@ -35,7 +35,7 @@
 			"nameNote": "working name",
 			"status": "experimental",
 			"statusLabel": "Experimental",
-			"description": "A rebase-friendly ETC client built as just 9 commits on top of unmodified upstream go-ethereum. Designed so that upstream improvements can be absorbed with a straightforward rebase. Currently in continuous testing, investigating bad block propagation issues specific to PoW networks.",
+			"description": "A rebase-friendly ETC client built as just 9 commits on top of unmodified upstream go-ethereum. Designed so that upstream improvements can be absorbed with a straightforward rebase. Investigation of bad block propagation on PoW networks traced the root cause to a PathDB bug where side-chain blocks with duplicate state roots silently corrupt canonical state reads. Fix submitted upstream.",
 			"repo": "https://github.com/diega/go-ethereum-classic",
 			"links": [
 				{
@@ -43,12 +43,8 @@
 					"url": "https://github.com/ethereum/go-ethereum/issues/32386"
 				},
 				{
-					"label": "State corruption fix",
-					"url": "https://github.com/ethereum/go-ethereum/pull/33931"
-				},
-				{
-					"label": "PathDB lock fix",
-					"url": "https://github.com/ethereum/go-ethereum/pull/33622"
+					"label": "Root cause fix (open, upstream)",
+					"url": "https://github.com/ethereum/go-ethereum/pull/34642"
 				}
 			]
 		},


### PR DESCRIPTION
## Summary
- Updated description: bad block investigation found the root cause — a PathDB bug where side-chain blocks with duplicate state roots silently corrupt canonical state reads
- Added link to upstream fix PR (ethereum/go-ethereum#34642)
- Removed unrelated links (#33931, #33622) that turned out not to be related

**Depends on** #304

## Test plan
- [ ] Verify Go-Ethereum-Classic section renders correctly on Development page

🤖 Generated with [Claude Code](https://claude.com/claude-code)